### PR TITLE
Handle broadcasted operators

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -188,3 +188,7 @@ function replace_op!(expr::Expr, op_map::Dict)
     end
     return expr
 end
+
+if VERSION < v"1.6"
+    isexpr(expr, heads) = isexpr(expr, collect(heads))
+end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -131,12 +131,22 @@ function replace_op!(expr::Expr, op_map::Dict)
             else
                 expr.args[1] = op
             end
-        elseif op ∈ keys(broadcast_op_map) # broadcast operators
+        elseif op ∈ keys(broadcast_op_map)        # broadcast operators
             op = get(broadcast_op_map, op, op)
-            expr.head = :.
-            expr.args = [
-                get(op_map, op, op),
-                Expr(:tuple, expr.args[2:end]...)]
+            if length(expr.args) == 2 # unary operator
+                if op == :-
+                    expr.head = :.
+                    expr.args = [
+                        get(op_map, Symbol("unary-"), op),
+                        Expr(:tuple, expr.args[2])]
+                end
+                # no action required for .+
+            else
+                expr.head = :.
+                expr.args = [
+                    get(op_map, op, op),
+                    Expr(:tuple, expr.args[2:end]...)]
+            end
         else                                      # arbitrary call
             op = get(op_map, op, op)
             if isexpr(f, :.)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -193,5 +193,6 @@ function replace_op!(expr::Expr, op_map::Dict)
 end
 
 if VERSION < v"1.6"
+    import Base.Meta: isexpr
     isexpr(expr, heads) = isexpr(expr, collect(heads))
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -179,6 +179,9 @@ function replace_op!(expr::Expr, op_map::Dict)
         op = get(assignment_op_map, op, op)
         expr.head = startswith(string(op), ".") ? :.= : :(=) # is there a better test?
         expr.args[2] = replace_op!(Expr(:call, op, target, arg), op_map)
+    elseif isexpr(expr, :.) # broadcast function
+        op = expr.args[1]
+        expr.args[1] = get(op_map, op, op)
     elseif !isexpr(expr, :macrocall) || expr.args[1] ∉ (Symbol("@checked"), Symbol("@unchecked"))
         for a in expr.args
             if isa(a, Expr)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -79,10 +79,6 @@ const op_checked = Dict(
     :- => :(checked_sub),
     :* => :(checked_mul),
     :^ => :(checked_pow),
-    :+= => :(checked_add),
-    :-= => :(checked_sub),
-    :*= => :(checked_mul),
-    :^= => :(checked_pow),
     :abs => :(checked_abs),
 )
 
@@ -93,10 +89,6 @@ const op_unchecked = Dict(
     :- => :(unchecked_sub),
     :* => :(unchecked_mul),
     :^ => :(unchecked_pow),
-    :+= => :(unchecked_add),
-    :-= => :(unchecked_sub),
-    :*= => :(unchecked_mul),
-    :^= => :(unchecked_pow),
     :abs => :(unchecked_abs)
 )
 
@@ -139,7 +131,7 @@ function replace_op!(expr::Expr, op_map::Dict)
             else
                 expr.args[1] = op
             end
-        elseif op ∈ (:.+, :.-, :.*, :.^) # broadcast operators
+        elseif op ∈ keys(broadcast_op_map) # broadcast operators
             op = get(broadcast_op_map, op, op)
             expr.head = :.
             expr.args = [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -306,6 +306,10 @@ end
     aa = fill(typemax(Int), 2)
     bb = fill(2, 2)
     cc = fill(typemin(Int), 2)
+    @unchecked(.+cc) == cc
+    @unchecked(.-cc) == cc
+    @checked(.+cc) == cc
+    @test_throws OverflowError @checked(.-cc)
     @unchecked(aa .+ bb) == fill(typemin(Int) + 1, 2)
     @test_throws OverflowError @checked aa .+ bb
     @unchecked(cc .- bb) == fill(typemax(Int) - 1, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -301,3 +301,17 @@ using SaferIntegers
             @test_throws OverflowError typemax(SafeInt) + 1
         end))
 end
+
+@testset "Broadcasted operators replaced" begin
+    aa = fill(typemax(Int), 2)
+    bb = fill(2, 2)
+    cc = fill(typemin(Int), 2)
+    @unchecked(aa .+ bb) == fill(typemin(Int) + 1, 2)
+    @test_throws OverflowError @checked aa .+ bb
+    @unchecked(cc .- bb) == fill(typemax(Int) - 1, 2)
+    @test_throws OverflowError @checked cc .- bb
+    @unchecked(aa .* bb) == fill(-2, 2)
+    @test_throws OverflowError @checked aa .* bb
+    @unchecked(aa .^ bb) == fill(1, 2)
+    @test_throws OverflowError @checked aa .^ bb
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -315,3 +315,17 @@ end
     @unchecked(aa .^ bb) == fill(1, 2)
     @test_throws OverflowError @checked aa .^ bb
 end
+
+@testset "Broadcasted assignment operators replaced" begin
+    aa = fill(typemax(Int), 2)
+    bb = fill(2, 2)
+    cc = fill(typemin(Int), 2)
+    @unchecked(copy(aa) .+= bb) == fill(typemin(Int) + 1, 2)
+    @test_throws OverflowError @checked aa .+ bb
+    @unchecked(copy(cc) .-= bb) == fill(typemax(Int) - 1, 2)
+    @test_throws OverflowError @checked cc .- bb
+    @unchecked(copy(aa) .* bb) == fill(-2, 2)
+    @test_throws OverflowError @checked aa .* bb
+    @unchecked(copy(aa) .^ bb) == fill(1, 2)
+    @test_throws OverflowError @checked aa .^ bb
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -334,6 +334,7 @@ end
     @test_throws OverflowError @checked aa .* bb
     @unchecked(copy(aa) .^ bb) == fill(1, 2)
     @test_throws OverflowError @checked aa .^ bb
+end
 
 @testset "Elementwise array methods are replaced, and others throw" begin
     aa = fill(typemax(Int), 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -318,6 +318,8 @@ end
     @test_throws OverflowError @checked aa .* bb
     @unchecked(aa .^ bb) == fill(1, 2)
     @test_throws OverflowError @checked aa .^ bb
+    @unchecked(abs.(cc)) == cc
+    @test_throws OverflowError @checked abs.(cc)
 end
 
 @testset "Broadcasted assignment operators replaced" begin


### PR DESCRIPTION
This PR replaces `.+`, `.-`, `.*`, `.^` with calls to `checked_add.`, `checked_sub.`/`checked_neg.`, `checked_mul.`, `checked_pow.`

Partially addresses #11