### PR TITLE
Add saturating array methods, which was overlooked by #7

### DIFF
--- a/src/abstractarraymath_ext.jl
+++ b/src/abstractarraymath_ext.jl
@@ -19,6 +19,19 @@ checked_mul(A::AbstractArray, B::AbstractArray) = error("Checked matrix multipli
 
 checked_pow(A::AbstractArray, B::Number) = error("Checked matrix multiplication is not available")
 
+saturating_neg(A::AbstractArray) = broadcast_preserving_zero_d(saturating_neg, A)
+for f in (:saturating_add, :saturating_sub)
+    @eval function ($f)(A::AbstractArray, B::AbstractArray)
+        promote_shape(A, B) # check size compatibility
+        broadcast_preserving_zero_d($f, A, B)
+    end
+end
+saturating_mul(A::Number, B::AbstractArray) = broadcast_preserving_zero_d(saturating_mul, B, A)
+saturating_mul(A::AbstractArray, B::Number) = broadcast_preserving_zero_d(saturating_mul, A, B)
+saturating_mul(A::AbstractArray, B::AbstractArray) = error("Saturating matrix multiplication is not available")
+
+saturating_pow(A::AbstractArray, B::Number) = error("Saturating matrix multiplication is not available")
+
 # Compatibility with Julia 1.0 and 1.1
 if VERSION < v"1.2"
     if VERSION < v"1.1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -426,34 +426,51 @@ end
     aa = fill(typemax(Int), 2)
     bb = fill(2, 2)
     cc = fill(typemin(Int), 2)
-    @unchecked(.+cc) == cc
-    @unchecked(.-cc) == cc
+
     @checked(.+cc) == cc
     @test_throws OverflowError @checked(.-cc)
-    @unchecked(aa .+ bb) == fill(typemin(Int) + 1, 2)
     @test_throws OverflowError @checked aa .+ bb
-    @unchecked(cc .- bb) == fill(typemax(Int) - 1, 2)
     @test_throws OverflowError @checked cc .- bb
-    @unchecked(aa .* bb) == fill(-2, 2)
     @test_throws OverflowError @checked aa .* bb
-    @unchecked(aa .^ bb) == fill(1, 2)
     @test_throws OverflowError @checked aa .^ bb
-    @unchecked(abs.(cc)) == cc
     @test_throws OverflowError @checked abs.(cc)
+
+    @unchecked(.+cc) == cc
+    @unchecked(.-cc) == cc
+    @unchecked(aa .+ bb) == fill(typemin(Int) + 1, 2)
+    @unchecked(cc .- bb) == fill(typemax(Int) - 1, 2)
+    @unchecked(aa .* bb) == fill(-2, 2)
+    @unchecked(aa .^ bb) == fill(1, 2)
+    @unchecked(abs.(cc)) == cc
+
+    @saturating(.+cc) == cc
+    @saturating(.-cc) == aa
+    @saturating(aa .+ bb) == aa
+    @saturating(cc .- bb) == cc
+    @saturating(aa .* bb) == aa
+    @saturating(aa .^ bb) == aa
+    @saturating(abs.(cc)) == aa
 end
 
 @testset "Broadcasted assignment operators replaced" begin
     aa = fill(typemax(Int), 2)
     bb = fill(2, 2)
     cc = fill(typemin(Int), 2)
-    @unchecked(copy(aa) .+= bb) == fill(typemin(Int) + 1, 2)
+    
     @test_throws OverflowError @checked aa .+ bb
-    @unchecked(copy(cc) .-= bb) == fill(typemax(Int) - 1, 2)
-    @test_throws OverflowError @checked cc .- bb
-    @unchecked(copy(aa) .* bb) == fill(-2, 2)
-    @test_throws OverflowError @checked aa .* bb
-    @unchecked(copy(aa) .^ bb) == fill(1, 2)
     @test_throws OverflowError @checked aa .^ bb
+    @test_throws OverflowError @checked cc .- bb
+    @test_throws OverflowError @checked aa .* bb
+
+    @unchecked(copy(aa) .+= bb) == fill(typemin(Int) + 1, 2)
+    @unchecked(copy(cc) .-= bb) == fill(typemax(Int) - 1, 2)
+    @unchecked(copy(aa) .* bb) == fill(-2, 2)
+    @unchecked(copy(aa) .^ bb) == fill(1, 2)
+
+    @saturating(copy(aa) .+= bb) == aa
+    @saturating(copy(cc) .-= bb) == cc
+    @saturating(copy(aa) .* bb) == aa
+    @saturating(copy(aa) .^ bb) == aa
 end
 
 @testset "Elementwise array methods are replaced, and others throw" begin
@@ -461,20 +478,31 @@ end
     bb = fill(2, 2)
     cc = fill(typemin(Int), 2)
     dd = fill(typemax(Int), 2, 2)
-    @unchecked(+cc) == cc
-    @unchecked(-cc) == cc
+
     @checked(+cc) == cc
     @test_throws OverflowError @checked(-cc)
-    @unchecked(aa + bb) == fill(typemin(Int) + 1, 2)
     @test_throws OverflowError @checked aa + bb
-    @unchecked(cc - bb) == fill(typemax(Int) - 1, 2)
     @test_throws OverflowError @checked cc - bb
-    @unchecked(2aa) == fill(-2, 2)
     @test_throws OverflowError @checked 2aa
-    @unchecked(aa * 2) == fill(-2, 2)
     @test_throws OverflowError @checked aa * 2
-    @unchecked(aa * bb') == fill(-2, 2, 2)
     @test_throws ErrorException @checked aa * bb'
-    @unchecked(dd ^ 2) == fill(2, 2, 2)
     @test_throws ErrorException @checked dd ^ 2
+
+    @unchecked(+cc) == cc
+    @unchecked(-cc) == cc
+    @unchecked(aa + bb) == fill(typemin(Int) + 1, 2)
+    @unchecked(cc - bb) == fill(typemax(Int) - 1, 2)
+    @unchecked(2aa) == fill(-2, 2)
+    @unchecked(aa * 2) == fill(-2, 2)
+    @unchecked(aa * bb') == fill(-2, 2, 2)
+    @unchecked(dd ^ 2) == fill(2, 2, 2)
+
+    @saturating(+cc) == cc
+    @saturating(-cc) == aa
+    @saturating(aa + bb) == aa
+    @saturating(cc - bb) == cc
+    @saturating(2aa) == aa
+    @saturating(aa * 2) == aa
+    @test_throws ErrorException @saturating aa * bb'
+    @test_throws ErrorException @saturating dd ^ 2
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -413,11 +413,20 @@ using SaferIntegers
 
 @testset "Ensure SaferIntegers are still safer" begin
     @test_throws OverflowError typemax(SafeInt) + 1
+
     @test_throws OverflowError @unchecked typemax(SafeInt) + 1
+    @test_throws OverflowError @saturating typemax(SafeInt) + 1
+
     (@__MODULE__).eval(:(
         module UncheckedDefaultSaferIntStillChecksModule
             using OverflowContexts, SaferIntegers, Test
             @default_unchecked
+            @test_throws OverflowError typemax(SafeInt) + 1
+        end))
+    (@__MODULE__).eval(:(
+        module SaturatingDefaultSaferIntStillChecksModule
+            using OverflowContexts, SaferIntegers, Test
+            @default_saturating
             @test_throws OverflowError typemax(SafeInt) + 1
         end))
 end


### PR DESCRIPTION
Also adds appropriate tests and expands a test for SaferIntegers with `saturating`