### PR TITLE
Add `div` family methods (`div`, `cld`, `fld`, `rem`, `mod`)

### DIFF
--- a/src/OverflowContexts.jl
+++ b/src/OverflowContexts.jl
@@ -6,8 +6,8 @@ include("base_ext_sat.jl")
 include("abstractarraymath_ext.jl")
 
 export @default_checked, @default_unchecked, @default_saturating, @checked, @unchecked, @saturating,
-    checked_neg, checked_add, checked_sub, checked_mul, checked_pow, checked_negsub, checked_abs,
-    unchecked_neg, unchecked_add, unchecked_sub, unchecked_mul, unchecked_negsub, unchecked_pow, unchecked_abs,
-    saturating_neg, saturating_add, saturating_sub, saturating_mul, saturating_pow, saturating_negsub, saturating_abs
+    checked_neg, checked_add, checked_sub, checked_mul, checked_pow, checked_negsub, checked_abs, checked_div, checked_fld, checked_cld, checked_rem, checked_mod,
+    unchecked_neg, unchecked_add, unchecked_sub, unchecked_mul, unchecked_negsub, unchecked_pow, unchecked_abs, unchecked_div, unchecked_fld, unchecked_cld, unchecked_rem, unchecked_mod,
+    saturating_neg, saturating_add, saturating_sub, saturating_mul, saturating_pow, saturating_negsub, saturating_abs, saturating_div, saturating_fld, saturating_cld, saturating_rem, saturating_mod
 
 end # module

--- a/src/base_ext.jl
+++ b/src/base_ext.jl
@@ -26,8 +26,8 @@ unchecked_abs(x...) = Base.abs(x...)
 checked_div(x...) = Base.:÷(x...)
 checked_fld(x...) = Base.fld(x...)
 checked_cld(x...) = Base.cld(x...)
-checked_rem(x...) = Base.rem(x...)
-checked_mod(x...) = Base.:%(x...)
+checked_rem(x...) = Base.:%(x...) # Yes, % is `rem`, not `mod`
+checked_mod(x...) = Base.mod(x...)
 checked_divrem(x...) = Base.divrem(x...)
 
 # convert multi-argument calls into nested two-argument calls

--- a/src/base_ext_sat.jl
+++ b/src/base_ext_sat.jl
@@ -80,8 +80,10 @@ function saturating_div(x::T, y::T) where T <: SignedBitInteger
 end
 saturating_div(x::T, y::T) where T <: UnsignedBitInteger =
     (y == zero(T)) ?
-        zero(T) :
-        Base.sdiv_int(x, y)
+        (x == zero(T) ?
+            zero(T) :
+            typemax(T)) :
+        Base.udiv_int(x, y)
 
 function saturating_fld(x::T, y::T) where T <: SignedBitInteger
     d = saturating_div(x, y)

--- a/src/base_ext_sat.jl
+++ b/src/base_ext_sat.jl
@@ -6,8 +6,6 @@ if VERSION ≤ v"1.11-alpha"
 end
 
 # saturating implementations
-const SignedBitInteger = Union{Int8, Int16, Int32, Int64, Int128}
-
 saturating_neg(x::T) where T <: BitInteger = saturating_sub(zero(T), x)
 
 if VERSION ≥ v"1.5"
@@ -68,3 +66,50 @@ function saturating_abs(x::T) where T <: SignedBitInteger
     result = flipsign(x, x)
     return result < 0 ? typemax(T) : result
 end
+
+# for saturating, letting `÷ -1` be negated with saturation, and `÷ 0` be the type min,
+# 0, or max based on the sign of the dividend
+function saturating_div(x::T, y::T) where T <: SignedBitInteger
+    return (y == zero(T)) ?
+        ((x == zero(T)) ?
+            zero(T) :
+            saturating_mul(-sign(x), typemin(T))) :
+        (y == -one(T)) ?
+            saturating_neg(x) :
+            Base.sdiv_int(x, y)
+end
+saturating_div(x::T, y::T) where T <: UnsignedBitInteger =
+    (y == zero(T)) ?
+        zero(T) :
+        Base.sdiv_int(x, y)
+
+function saturating_fld(x::T, y::T) where T <: SignedBitInteger
+    d = saturating_div(x, y)
+    return @saturating d - (signbit(x ⊻ y) & (d * y != x))
+end
+saturating_fld(x::T, y::T) where T <: UnsignedBitInteger = saturating_div(x, y)
+
+function saturating_cld(x::T, y::T) where T <: SignedBitInteger
+    d = saturating_div(x, y)
+    return @saturating d + (((x > 0) == (y > 0)) & (d * y != x))
+end
+function saturating_cld(x::T, y::T) where T <: UnsignedBitInteger
+    d = saturating_div(x, y)
+    return @saturating d + (d * y != x)
+end
+
+saturating_rem(x::T, y::T) where T <: SignedBitInteger =
+    (y == zero(T)) ?
+        x :
+        (y == -one(T)) ?
+            zero(T) :
+            Base.srem_int(x, y)
+saturating_rem(x::T, y::T) where T <: UnsignedBitInteger =
+    (y == zero(T)) ?
+        x :
+        Base.urem_int(x, y)
+
+saturating_mod(x::T, y::T) where T <: SignedBitInteger = @saturating x - fld(x, y) * y
+saturating_mod(x::T, y::T) where T <: UnsignedBitInteger = @saturating rem(x, y)
+
+saturating_divrem(x::T, y::T) where T <: BitInteger = @saturating div(x, y), rem(x, y)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,6 +1,6 @@
 using Base.Meta: isexpr
 
-const op_method_symbols = (:+, :-, :*, :^, :abs, :÷, :div, :cld, :fld, :rem, :mod, :%)
+const op_method_symbols = (:+, :-, :*, :^, :abs, :÷, :div, :cld, :fld, :%, :rem, :mod)
 
 """
     @default_checked
@@ -25,8 +25,8 @@ macro default_checked()
         (@__MODULE__).eval(:(div(x) = checked_div(x)))
         (@__MODULE__).eval(:(fld(x) = checked_fld(x)))
         (@__MODULE__).eval(:(cld(x) = checked_cld(x)))
-        (@__MODULE__).eval(:(rem(x) = checked_rem(x)))
         (@__MODULE__).eval(:(%(x...) = checked_mod(x...)))
+        (@__MODULE__).eval(:(rem(x) = checked_rem(x)))
         (@__MODULE__).eval(:(mod(x) = checked_mod(x)))
         (@__MODULE__).eval(:(__OverflowContextDefaultSet = true))
         nothing
@@ -56,8 +56,8 @@ macro default_unchecked()
         (@__MODULE__).eval(:(div(x) = unchecked_div(x)))
         (@__MODULE__).eval(:(fld(x) = unchecked_fld(x)))
         (@__MODULE__).eval(:(cld(x) = unchecked_cld(x)))
-        (@__MODULE__).eval(:(rem(x) = unchecked_rem(x)))
         (@__MODULE__).eval(:(%(x...) = unchecked_mod(x...)))
+        (@__MODULE__).eval(:(rem(x) = unchecked_rem(x)))
         (@__MODULE__).eval(:(mod(x) = unchecked_mod(x)))
         (@__MODULE__).eval(:(__OverflowContextDefaultSet = true))
         nothing
@@ -87,8 +87,8 @@ macro default_saturating()
         (@__MODULE__).eval(:(div(x) = OverflowContexts.saturating_div(x)))
         (@__MODULE__).eval(:(fld(x) = OverflowContexts.saturating_fld(x)))
         (@__MODULE__).eval(:(cld(x) = OverflowContexts.saturating_cld(x)))
-        (@__MODULE__).eval(:(rem(x) = OverflowContexts.saturating_rem(x)))
         (@__MODULE__).eval(:(%(x...) = OverflowContexts.saturating_mod(x...)))
+        (@__MODULE__).eval(:(rem(x) = OverflowContexts.saturating_rem(x)))
         (@__MODULE__).eval(:(mod(x) = OverflowContexts.saturating_mod(x)))
         (@__MODULE__).eval(:(__OverflowContextDefaultSet = true))
         nothing
@@ -140,8 +140,8 @@ const op_checked = Dict(
     :div => :(checked_div),
     :fld => :(checked_fld),
     :cld => :(checked_cld),
+    :% => :(checked_rem),
     :rem => :(checked_rem),
-    :% => :(checked_mod),
     :mod => :(checked_mod)
 )
 
@@ -157,8 +157,8 @@ const op_unchecked = Dict(
     :div => :(unchecked_div),
     :fld => :(unchecked_fld),
     :cld => :(unchecked_cld),
+    :% => :(unchecked_rem),
     :rem => :(unchecked_rem),
-    :% => :(unchecked_mod),
     :mod => :(unchecked_mod)
 )
 
@@ -174,8 +174,8 @@ const op_saturating = Dict(
     :div => :(saturating_div),
     :fld => :(saturating_fld),
     :cld => :(saturating_cld),
+    :% => :(saturating_rem),
     :rem => :(saturating_rem),
-    :% => :(saturating_mod),
     :mod => :(saturating_mod)
 )
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,6 +1,6 @@
 using Base.Meta: isexpr
 
-const op_method_symbols = (:+, :-, :*, :^, :abs)
+const op_method_symbols = (:+, :-, :*, :^, :abs, :÷, :div, :cld, :fld, :rem, :mod, :%)
 
 """
     @default_checked
@@ -21,6 +21,13 @@ macro default_checked()
         (@__MODULE__).eval(:(*(x...) = checked_mul(x...)))
         (@__MODULE__).eval(:(^(x...) = checked_pow(x...)))
         (@__MODULE__).eval(:(abs(x) = checked_abs(x)))
+        (@__MODULE__).eval(:(÷(x...) = checked_div(x...)))
+        (@__MODULE__).eval(:(div(x) = checked_div(x)))
+        (@__MODULE__).eval(:(fld(x) = checked_fld(x)))
+        (@__MODULE__).eval(:(cld(x) = checked_cld(x)))
+        (@__MODULE__).eval(:(rem(x) = checked_rem(x)))
+        (@__MODULE__).eval(:(%(x...) = checked_mod(x...)))
+        (@__MODULE__).eval(:(mod(x) = checked_mod(x)))
         (@__MODULE__).eval(:(__OverflowContextDefaultSet = true))
         nothing
     end
@@ -45,6 +52,13 @@ macro default_unchecked()
         (@__MODULE__).eval(:(*(x...) = unchecked_mul(x...)))
         (@__MODULE__).eval(:(^(x...) = unchecked_pow(x...)))
         (@__MODULE__).eval(:(abs(x) = unchecked_abs(x)))
+        (@__MODULE__).eval(:(÷(x...) = unchecked_div(x...)))
+        (@__MODULE__).eval(:(div(x) = unchecked_div(x)))
+        (@__MODULE__).eval(:(fld(x) = unchecked_fld(x)))
+        (@__MODULE__).eval(:(cld(x) = unchecked_cld(x)))
+        (@__MODULE__).eval(:(rem(x) = unchecked_rem(x)))
+        (@__MODULE__).eval(:(%(x...) = unchecked_mod(x...)))
+        (@__MODULE__).eval(:(mod(x) = unchecked_mod(x)))
         (@__MODULE__).eval(:(__OverflowContextDefaultSet = true))
         nothing
     end
@@ -69,6 +83,13 @@ macro default_saturating()
         (@__MODULE__).eval(:(*(x...) = OverflowContexts.saturating_mul(x...)))
         (@__MODULE__).eval(:(^(x...) = OverflowContexts.saturating_pow(x...)))
         (@__MODULE__).eval(:(abs(x) = OverflowContexts.saturating_abs(x)))
+        (@__MODULE__).eval(:(÷(x...) = OverflowContexts.saturating_div(x...)))
+        (@__MODULE__).eval(:(div(x) = OverflowContexts.saturating_div(x)))
+        (@__MODULE__).eval(:(fld(x) = OverflowContexts.saturating_fld(x)))
+        (@__MODULE__).eval(:(cld(x) = OverflowContexts.saturating_cld(x)))
+        (@__MODULE__).eval(:(rem(x) = OverflowContexts.saturating_rem(x)))
+        (@__MODULE__).eval(:(%(x...) = OverflowContexts.saturating_mod(x...)))
+        (@__MODULE__).eval(:(mod(x) = OverflowContexts.saturating_mod(x)))
         (@__MODULE__).eval(:(__OverflowContextDefaultSet = true))
         nothing
     end
@@ -115,6 +136,13 @@ const op_checked = Dict(
     :* => :(checked_mul),
     :^ => :(checked_pow),
     :abs => :(checked_abs),
+    :÷ => :(checked_div),
+    :div => :(checked_div),
+    :fld => :(checked_fld),
+    :cld => :(checked_cld),
+    :rem => :(checked_rem),
+    :% => :(checked_mod),
+    :mod => :(checked_mod)
 )
 
 const op_unchecked = Dict(
@@ -124,7 +152,14 @@ const op_unchecked = Dict(
     :- => :(unchecked_sub),
     :* => :(unchecked_mul),
     :^ => :(unchecked_pow),
-    :abs => :(unchecked_abs)
+    :abs => :(unchecked_abs),
+    :÷ => :(unchecked_div),
+    :div => :(unchecked_div),
+    :fld => :(unchecked_fld),
+    :cld => :(unchecked_cld),
+    :rem => :(unchecked_rem),
+    :% => :(unchecked_mod),
+    :mod => :(unchecked_mod)
 )
 
 const op_saturating = Dict(
@@ -134,14 +169,23 @@ const op_saturating = Dict(
     :- => :(saturating_sub),
     :* => :(saturating_mul),
     :^ => :(saturating_pow),
-    :abs => :(saturating_abs)
+    :abs => :(saturating_abs),
+    :÷ => :(saturating_div),
+    :div => :(saturating_div),
+    :fld => :(saturating_fld),
+    :cld => :(saturating_cld),
+    :rem => :(saturating_rem),
+    :% => :(saturating_mod),
+    :mod => :(saturating_mod)
 )
 
 const broadcast_op_map = Dict(
     :.+ => :+,
     :.- => :-,
     :.* => :*,
-    :.^ => :^
+    :.^ => :^,
+    :.÷ => :÷,
+    :.% => :%
 )
 
 const assignment_op_map = Dict(
@@ -149,10 +193,14 @@ const assignment_op_map = Dict(
     :-= => :-,
     :*= => :*,
     :^= => :^,
+    :÷= => :÷,
+    :%= => :%,
     :.+= => :.+,
     :.-= => :.-,
     :.*= => :.*,
     :.^= => :.^,
+    :.÷= => :.÷,
+    :.%= => :.%
 )
 
 # resolve ambiguity when `-` used as symbol


### PR DESCRIPTION
This PR adds the `div` family methods (`div`, `cld`, `fld`, `rem`, `mod`) and operators (`÷`, `%`) to the set.

Since integer division is so slow (see #9), we can afford branches to avoid undefined behavior.

For `unchecked` methods, we're defining divide-by-zero to produce zero, and `typemin() ÷ -1` to overflow to `typemin(Int)`.

For `saturating` methods, we're defining divide-by-zero to produce `typemin()`, `zero()` or `typemax()` based on the sign of the dividend, and `typemin() ÷ -1` produces `typemax()`.

`divrem` isn't present at the moment because `Base.Checked` doesn't implement that.